### PR TITLE
Correction d'un bug d'affichage lors de la remise à zéro de la sauvegarde

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,6 +12,13 @@
         vm.displayOwnedMonsters = locker.get('displayOwnedMonsters', true);
         vm.displayFinishedZones = locker.get('displayFinishedZones', true);
         vm.displayFinishedSteps = locker.get('displayFinishedSteps', true);
+        // Initialisation de la variable selectedType
+        vm.selectedType = '';
+
+        // Fonction pour filtrer les monstres par type
+        vm.filterByType = function(monster) {
+            return vm.selectedType === '' || monster.type === vm.selectedType;
+        };
 
         vm.isOwned = function(monster) {
             if (!vm.saveData || !monster) {

--- a/app.js
+++ b/app.js
@@ -175,10 +175,37 @@
             locker.put('displayFinishedSteps', vm.displayFinishedSteps);
         }
 
+        // Fonction pour charger les monstres
+        vm.loadMonsters = function() {
+            $http.get('monsters.json').then(function(res) {
+                vm.monsters = res.data;
+                vm.zones = {};
+                vm.steps = [];
+    
+                angular.forEach(vm.monsters, function(monster) {
+                    angular.forEach(monster.zones, function(zone) {
+                        if (angular.isUndefined(vm.zones[zone])) {
+                            vm.zones[zone] = [];
+                        }
+                        vm.zones[zone].push(monster);
+                    });
+    
+                    if (angular.isUndefined(vm.steps[monster.step])) {
+                        vm.steps[monster.step] = [];
+                    }
+                    vm.steps[monster.step].push(monster);
+                });
+            });
+        };
+    
+        // Appelez cette fonction pour initialiser les monstres
+        vm.loadMonsters();
+    
         vm.resetAll = function() {
             if (confirm('Dernière chance !')) {
                 locker.clean();
-
+    
+                // Réinitialisez vos variables ici
                 vm.sorting = 0;
                 vm.saveData = null;
                 vm.displayOwnedMonsters = true;
@@ -187,8 +214,11 @@
                 vm.zones = {};
                 vm.steps = [];
                 vm.monsters = [];
-
+    
                 $('#saveModal').modal('hide');
+    
+                // Rechargez les monstres après la réinitialisation
+                vm.loadMonsters();
             }
         };
 

--- a/index.html
+++ b/index.html
@@ -124,6 +124,16 @@
                             <input ng-model="search.$" style="width:100%" placeholder="Rechercher" class="form-control"/>
                         </div>
 
+                        <!-- Selecteur de type -->
+                        <select class="form-group" ng-model="appCtrl.selectedType">
+                            <option value="">Tous les types</option>
+                            <option value="monster">Monstres</option>
+                            <option value="archi">Archi-monstres</option>
+                            <option value="boss">Boss de donjons</option>
+
+                        </select>
+
+
                         <table class="table table-stripped table-hover table-bordered">
                             <thead>
                                 <tr>
@@ -135,8 +145,8 @@
                             </thead>
 
                             <tbody>
-                                <tr ng-repeat="monster in appCtrl.monsters | orderBy:'name' | filter:search" ng-class="{success: appCtrl.isOwned(monster)}" ng-click="appCtrl.toggleMonster(monster)" ng-hide="appCtrl.displayOwnedMonsters && appCtrl.isOwned(monster)">
-                                    <td><input type="checkbox" ng-checked="appCtrl.isOwned(monster)" /></td>
+                                <!-- Modification du ng-repeat avec l'ajout du tri par type -->
+                                <tr ng-repeat="monster in appCtrl.monsters | orderBy:'name' | filter:search | filter:appCtrl.filterByType" ng-class="{success: appCtrl.isOwned(monster)}" ng-click="appCtrl.toggleMonster(monster)" ng-hide="appCtrl.displayOwnedMonsters && appCtrl.isOwned(monster)">                                    <td><input type="checkbox" ng-checked="appCtrl.isOwned(monster)" /></td>
                                     <td>
                                         <i class="glyphicon glyphicon-star" ng-if="monster.type == 'boss'"></i>
                                         <i class="glyphicon glyphicon-fire" ng-if="monster.type == 'archi'"></i>


### PR DESCRIPTION
Lors de la remise à zéro, il y avait un bug d'affichage, la liste des monstres ne s'affichant plus, à part lors du rechargement de la page. J'ai créé une fonction qui réinitialise la liste des monstres et la réaffiche dynamiquement après le reset, sans avoir besoin de recharger la page + commit qui résout l'issue sur le filtre d'affichage grâce à la selection du type.